### PR TITLE
AQL query fixed

### DIFF
--- a/benchmark/arangodb/khop.java
+++ b/benchmark/arangodb/khop.java
@@ -39,12 +39,12 @@ class ArangoTask implements Callable<long[]> {
  
         String query = "FOR v IN "+depth+".."+depth+" OUTBOUND 'vertex/"+root+"' edge OPTIONS {bfs: true, uniqueVertices: 'global'} COLLECT WITH COUNT INTO counter RETURN counter";
         long startTime = System.nanoTime();
-        ArangoCursor<String> cursor = db.query(query, null, null, String.class);
+        ArangoCursor<Long> cursor = db.query(query, null, null, Long.class);
         long endTime = System.nanoTime();
         long diff = (endTime - startTime)/1000000;
         arangoDB.shutdown();
         
-        return new long[]{Long.valueOf(cursor.first().toString(), diff};
+        return new long[]{cursor.first(), diff};
     }
 }
 

--- a/benchmark/arangodb/khop.java
+++ b/benchmark/arangodb/khop.java
@@ -44,7 +44,7 @@ class ArangoTask implements Callable<long[]> {
         long diff = (endTime - startTime)/1000000;
         arangoDB.shutdown();
         
-        return new long[]{cursor.first(), diff};
+        return new long[]{Long.valueOf(cursor.first().toString(), diff};
     }
 }
 

--- a/benchmark/arangodb/khop.java
+++ b/benchmark/arangodb/khop.java
@@ -37,14 +37,14 @@ class ArangoTask implements Callable<long[]> {
     @Override
     public long[] call() throws Exception {
  
-        String query = "FOR v IN "+depth+".."+depth+" OUTBOUND 'vertex/"+root+"' edge RETURN distinct v._id";
+        String query = "FOR v IN "+depth+".."+depth+" OUTBOUND 'vertex/"+root+"' edge OPTIONS {bfs: true, uniqueVertices: 'global'} COLLECT WITH COUNT INTO counter RETURN counter";
         long startTime = System.nanoTime();
-        ArangoCursor<String> cursor = db.query(query, null, new AqlQueryOptions().count(true), String.class);
+        ArangoCursor<String> cursor = db.query(query, null, null, String.class);
         long endTime = System.nanoTime();
         long diff = (endTime - startTime)/1000000;
         arangoDB.shutdown();
         
-        return new long[]{cursor.count(), diff};
+        return new long[]{cursor.first(), diff};
     }
 }
 


### PR DESCRIPTION
Benchmarks are hard to get right, okay. So I hope you are open for a correction of an obvious glitch.
I wondered why the performance for ArangoDB is so bad.

What you do with ArangoDB in the **Graph500, 3 hops example**:

```
FOR v IN 3..3 OUTBOUND 'vertex/someStartNode' edge 
  RETURN distinct v._id
```

1. First, get all vertices that are 3 hops away from the 10 fixed nodes (10 separate runs). 
(These are 10,042,883 neighbours of 3rd grade).

2. Next, perform a `DISTINCT` to return just all unique `_id`.
Basically: "_Hey, I saw you 700 times, let's drop 699 now._"

3. Finally get a JSON of 10B IDs over the net and discard the result.
Isn't that benchmarking of network performance?

Imagine if you had used the following, corrected query instead:

Fixed query:
```
FOR v IN 3..3 OUTBOUND 'vertex/someStartNode' edge 
  OPTIONS {bfs: true, uniqueVertices: 'global'} 
  COLLECT WITH COUNT INTO counter 
  RETURN counter
```
Changes:
- breadth first search using unique vertices (we don't want to loop forever)
- ridiculous collection and returning of distinct vertex ids dropped (Only count is used).

This change improves the query runtime by **several orders of magnitude** and would perform 3 and 6 hops easily (in fact 3 or 6 hops would not impact query time significantly).

Now it does what the TigerGraph implementation does as well (bfs, count only) and could be compared.